### PR TITLE
Fix bug

### DIFF
--- a/lib/build-output.coffee
+++ b/lib/build-output.coffee
@@ -271,6 +271,10 @@ class BuildOutput
 
   shutdown: ->
     console.log "build output shutdown called"
+    @builder.removeAllListeners('start')
+    @builder.removeAllListeners('stdout')
+    @builder.removeAllListeners('stderr')
+    @builder.removeAllListeners('end')
     @editor.destroy()
 
 


### PR DESCRIPTION
Remove the old event listeners, so that the old BuildOutput is not called. Resulted in errors about destroyed TextEditor.